### PR TITLE
max_len structure now compatible with C++ < 14

### DIFF
--- a/include/nsimd/nsimd.h
+++ b/include/nsimd/nsimd.h
@@ -787,6 +787,8 @@ template <> struct max_len_t<f64> {
 
 #if NSIMD_CXX >= 2014
 template <typename T> constexpr int max_len = max_len_t<T>::value;
+#else
+template <typename T> int max_len = max_len_t<T>::value;
 #endif
 
 } // namespace nsimd


### PR DESCRIPTION
Fixed a bug where max_len was undefined when C++ version is less than C++ 14